### PR TITLE
fix: don't set docker by default

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -25,7 +25,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm i -g npminstall && npminstall
+    - run: npm install
     - run: npm run ci
       env:
         CI: true

--- a/config/config.default.js
+++ b/config/config.default.js
@@ -21,7 +21,6 @@ module.exports = appInfo => {
 
     logDir: 'xprofiler',
     logInterval: undefined,
-    docker: false,
     ipMode: false,
     libMode: true,
     errexp: /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/i,


### PR DESCRIPTION
> https://github.com/X-Profiler/xtransit/blob/master/orders/system_log.js#L52

在 `egg-xtransit` 中的 `config.default.js` 强制将 `docker` 配置为 `false` 会导致线上真实部署的容器此属性判断出错，所以从默认配置中移除。

当自动判断当前环境是否为容器的逻辑失效时，请手动在应用层的 Egg `xtransit` 配置中传入 `docker: true` 即可